### PR TITLE
Add the hydrus ebuild, originally in TheCrueltySage/vampire-overlay

### DIFF
--- a/media-gfx/hydrus/files/hydrus-client
+++ b/media-gfx/hydrus/files/hydrus-client
@@ -1,0 +1,3 @@
+#!/bin/sh
+export QT_API="${QT_API:-pyqt5}"
+/usr/bin/env python3 -OO /opt/hydrus/client.pyw "$@"

--- a/media-gfx/hydrus/files/hydrus-server
+++ b/media-gfx/hydrus/files/hydrus-server
@@ -1,0 +1,2 @@
+#!/bin/sh
+/usr/bin/env python3 -OO /opt/hydrus/server.py "$@"

--- a/media-gfx/hydrus/files/hydrus.desktop
+++ b/media-gfx/hydrus/files/hydrus.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Name=Hydrus Client
+Comment=A booru-like media organizer for the desktop
+Exec=hydrus-client
+Icon=/opt/hydrus/static/hydrus_non-transparent.png
+Terminal=false
+Type=Application
+Categories=AudioVideo;FileTools;Graphics;Network;

--- a/media-gfx/hydrus/files/paths-in-opt.patch
+++ b/media-gfx/hydrus/files/paths-in-opt.patch
@@ -1,0 +1,99 @@
+diff --git a/hydrus/client/gui/ClientGUI.py b/hydrus/client/gui/ClientGUI.py
+index c73d9a8..717afce 100644
+--- a/hydrus/client/gui/ClientGUI.py
++++ b/hydrus/client/gui/ClientGUI.py
+@@ -3903,7 +3903,7 @@ class FrameGUI( ClientGUITopLevelWindows.MainFrameThatResizes ):
+                             python_executable = python_executable.replace( 'pythonw', 'python' )
+                             
+                         
+-                        server_script_path = os.path.join( HC.BASE_DIR, 'server.py' )
++                        server_script_path = '/opt/hydrus/server.py'
+                         
+                         cmd = [ python_executable, server_script_path, db_param ]
+                         
+diff --git a/hydrus/core/HydrusConstants.py b/hydrus/core/HydrusConstants.py
+index a9eef8d..577d854 100644
+--- a/hydrus/core/HydrusConstants.py
++++ b/hydrus/core/HydrusConstants.py
+@@ -5,33 +5,9 @@ import typing
+ # old method of getting frozen dir, doesn't work for symlinks looks like:
+ # BASE_DIR = getattr( sys, '_MEIPASS', None )
+ 
+-RUNNING_FROM_FROZEN_BUILD = getattr( sys, 'frozen', False )
+-
+-if RUNNING_FROM_FROZEN_BUILD:
+-    
+-    real_exe_path = os.path.realpath( sys.executable )
+-    
+-    BASE_DIR = os.path.dirname( real_exe_path )
+-    
+-else:
+-    
+-    try:
+-        
+-        hc_realpath_dir = os.path.dirname( os.path.realpath( __file__ ) )
+-        
+-        HYDRUS_MODULE_DIR = os.path.split( hc_realpath_dir )[0]
+-        
+-        BASE_DIR = os.path.split( HYDRUS_MODULE_DIR )[0]
+-        
+-    except NameError: # if __file__ is not defined due to some weird OS
+-        
+-        BASE_DIR = os.path.realpath( sys.path[0] )
+-        
+-    
+-    if BASE_DIR == '':
+-        
+-        BASE_DIR = os.getcwd()
+-        
++RUNNING_FROM_FROZEN_BUILD = False
++HYDRUS_MODULE_DIR = '/opt/hydrus/hydrus'
++BASE_DIR = os.path.expanduser("~/.local/share/hydrus")
+ 
+ PLATFORM_WINDOWS = sys.platform == 'win32'
+ PLATFORM_MACOS  = sys.platform == 'darwin'
+@@ -41,32 +17,34 @@ PLATFORM_HAIKU = sys.platform == 'haiku1'
+ RUNNING_FROM_SOURCE = sys.argv[0].endswith( '.py' ) or sys.argv[0].endswith( '.pyw' )
+ RUNNING_FROM_MACOS_APP = os.path.exists( os.path.join( BASE_DIR, 'running_from_app' ) )
+ 
+-BIN_DIR = os.path.join( BASE_DIR, 'bin' )
+-HELP_DIR = os.path.join( BASE_DIR, 'help' )
+-INCLUDE_DIR = os.path.join( BASE_DIR, 'include' )
+-STATIC_DIR = os.path.join( BASE_DIR, 'static' )
++BIN_DIR = "/opt/hydrus/bin"
++HELP_DIR = "/opt/hydrus/help"
++INCLUDE_DIR = "/opt/hydrus/include"
++STATIC_DIR = "/opt/hydrus/static"
+ 
+ DEFAULT_DB_DIR = os.path.join( BASE_DIR, 'db' )
+ 
++
+ if PLATFORM_MACOS:
+-    
++
+     desired_userpath_db_dir = os.path.join( '~', 'Library', 'Hydrus' )
+-    
++
+ else:
+-    
++
+     desired_userpath_db_dir = os.path.join( '~', 'Hydrus' )
+-    
++
+ 
+ USERPATH_DB_DIR = os.path.expanduser( desired_userpath_db_dir )
+ 
++USERPATH_DB_DIR = DEFAULT_DB_DIR
++
+ if USERPATH_DB_DIR == desired_userpath_db_dir:
+     
+     # could not figure it out, probably a crazy user situation atm
+     
+     USERPATH_DB_DIR = None
+     
+-
+-LICENSE_PATH = os.path.join( BASE_DIR, 'license.txt' )
++LICENSE_PATH = "/usr/share/licenses/hydrus/license.txt"
+ 
+ #
+ 

--- a/media-gfx/hydrus/hydrus-9999.ebuild
+++ b/media-gfx/hydrus/hydrus-9999.ebuild
@@ -1,0 +1,99 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+EAPI=7
+
+PYTHON_COMPAT=( python{3_6,3_7,3_8,3_9} )
+
+inherit git-r3 eutils python-single-r1 desktop
+
+DESCRIPTION="*booru style image collector and viewer"
+HOMEPAGE="http://hydrusnetwork.github.io/hydrus/ https://github.com/hydrusnetwork/hydrus"
+EGIT_REPO_URI="https://github.com/hydrusnetwork/hydrus.git"
+IUSE="+ffmpeg miniupnpc +lz4 socks matplotlib"
+
+LICENSE="WTFPL"
+SLOT="0"
+KEYWORDS=""
+
+RDEPEND="$(python_gen_cond_dep '
+        media-libs/opencv[python,${PYTHON_MULTI_USEDEP}]
+
+        dev-python/QtPy[${PYTHON_MULTI_USEDEP}]
+        dev-python/beautifulsoup:4[${PYTHON_MULTI_USEDEP}]
+        dev-python/twisted[${PYTHON_MULTI_USEDEP}]
+        dev-python/requests[${PYTHON_MULTI_USEDEP}]
+        dev-python/numpy[${PYTHON_MULTI_USEDEP}]
+        dev-python/lxml[${PYTHON_MULTI_USEDEP}]
+        dev-python/pillow[${PYTHON_MULTI_USEDEP}]
+        dev-python/pyyaml[${PYTHON_MULTI_USEDEP}]
+        dev-python/psutil[${PYTHON_MULTI_USEDEP}]
+        dev-python/send2trash[${PYTHON_MULTI_USEDEP}]
+        dev-python/chardet[${PYTHON_MULTI_USEDEP}]
+        dev-python/html5lib[${PYTHON_MULTI_USEDEP}]
+        dev-python/nose[${PYTHON_MULTI_USEDEP}]
+        dev-python/six[${PYTHON_MULTI_USEDEP}]
+
+        sys-apps/coreutils
+        x11-libs/gtkglext
+
+        ffmpeg? ( media-video/ffmpeg )
+        miniupnpc? ( net-libs/miniupnpc )
+        lz4? ( dev-python/lz4[${PYTHON_MULTI_USEDEP}] )
+        socks? (
+                || ( dev-python/requests[socks5,${PYTHON_MULTI_USEDEP}]
+                    dev-python/PySocks[${PYTHON_MULTI_USEDEP}] )
+        )
+        matplotlib? ( dev-python/matplotlib[${PYTHON_MULTI_USEDEP}] )
+    ')
+    ${PYTHON_DEPS}"
+
+DEPEND="${RDEPEND}"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+src_prepare() {
+    eapply "${FILESDIR}/paths-in-opt.patch"
+
+    eapply_user
+
+    # remove useless directories and files due to paths-in-opt.patch
+    rm Readme.txt
+    rm -r db/
+
+    chmod a-x include/*.py
+    rm -f "include/pyconfig.h"
+    rm -f "include/Test"*.py
+    rm -f "test.py"
+    rm -rf "static/testing"
+}
+
+src_compile() {
+    python3 -OO -m compileall -f .
+}
+
+src_install() {
+    DOC="/usr/share/doc/${PF}"
+    elog "Hydrus includes an excellent manual, that can either be viewed at"
+    elog "${DOC}/html/index.html"
+    elog "or accessed through the hydrus help menu."
+
+    DOCS="COPYING README.md"
+    HTML_DOCS="${S}/help/"
+    einstalldocs
+
+    rm COPYING README.md
+    rm -r help/
+    ln -s "${DOC}/html" help
+
+    use ffmpeg && ln -s "$(which ffmpeg)" bin/ffmpeg
+
+    insopts -m0755
+    insinto /opt/${PN}
+    doins -r ${S}/* || die "Failed to move hydrus to opt."
+
+    exeinto /usr/bin
+    doexe "${FILESDIR}/hydrus-server"
+    doexe "${FILESDIR}/hydrus-client"
+
+    domenu "${FILESDIR}/hydrus.desktop"
+}

--- a/media-gfx/hydrus/metadata.xml
+++ b/media-gfx/hydrus/metadata.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <longdescription>
+    *booru-style image collector and tagger.
+  </longdescription>
+  <use>
+    <flag name="ffmpeg">Show duration and other information on video thumbnails</flag>
+    <flag name="miniupnpc">Support for automatic port forwarding</flag>
+    <flag name="lz4">Enable memory compression in the client</flag>
+    <flag name="socks">Support SOCKS proxies</flag>
+    <flag name="matplotlib">Support drawing bandwidth graphs</flag>
+  </use>
+</pkgmetadata>


### PR DESCRIPTION
The patch suggested in the TheCrueltySage/vampire-overlay#11 has been
applied.

Additionally, the dependencies have been fixed and a desktop
file (copied from the AUR package and fixed to satisfy gentoo QA:
https://aur.archlinux.org/packages/hydrus/) has been added.