### PR TITLE
media-gfx/hydrus: Use pyside2 and python-exec

### DIFF
--- a/media-gfx/hydrus/files/hydrus-client
+++ b/media-gfx/hydrus/files/hydrus-client
@@ -1,3 +1,3 @@
 #!/bin/sh
-export QT_API="${QT_API:-pyqt5}"
-/usr/bin/env python3 -OO /opt/hydrus/client.pyw "$@"
+export QT_API="${QT_API:-pyside2}"
+exec /usr/bin/python -OO /opt/hydrus/client.pyw "$@"

--- a/media-gfx/hydrus/files/hydrus-server
+++ b/media-gfx/hydrus/files/hydrus-server
@@ -1,2 +1,2 @@
 #!/bin/sh
-/usr/bin/env python3 -OO /opt/hydrus/server.py "$@"
+exec /usr/bin/python -OO /opt/hydrus/server.py "$@"

--- a/media-gfx/hydrus/hydrus-9999.ebuild
+++ b/media-gfx/hydrus/hydrus-9999.ebuild
@@ -10,7 +10,7 @@ inherit git-r3 eutils python-single-r1 desktop
 DESCRIPTION="*booru style image collector and viewer"
 HOMEPAGE="http://hydrusnetwork.github.io/hydrus/ https://github.com/hydrusnetwork/hydrus"
 EGIT_REPO_URI="https://github.com/hydrusnetwork/hydrus.git"
-IUSE="+mpv +ffmpeg miniupnpc +lz4 socks matplotlib +cloudscraper test"
+IUSE="+mpv +ffmpeg miniupnpc +lz4 socks matplotlib +cloudscraper charts test"
 
 LICENSE="WTFPL"
 SLOT="0"
@@ -40,6 +40,7 @@ RDEPEND="$(python_gen_cond_dep '
 		 dev-python/python-mpv[${PYTHON_MULTI_USEDEP}]
 	)
 	dev-python/pyyaml[${PYTHON_MULTI_USEDEP}]
+	dev-python/pyside2[widgets,gui,charts?,${PYTHON_MULTI_USEDEP}]
 	dev-python/QtPy[${PYTHON_MULTI_USEDEP}]
 	dev-python/requests[${PYTHON_MULTI_USEDEP}]
 	dev-python/send2trash[${PYTHON_MULTI_USEDEP}]
@@ -119,8 +120,12 @@ src_install() {
 	doins -r "${S}"/* || die "Failed to move hydrus to opt."
 
 	exeinto /usr/bin
-	doexe "${FILESDIR}/hydrus-server"
-	doexe "${FILESDIR}/hydrus-client"
+
+	sed "s/python/${EPYTHON}/" "${FILESDIR}/hydrus-server" > "${T}/hydrus-server"
+	sed "s/python/${EPYTHON}/" "${FILESDIR}/hydrus-client" > "${T}/hydrus-client"
+
+	python_doexe "${T}/hydrus-server"
+	python_doexe "${T}/hydrus-client"
 
 	domenu "${FILESDIR}/hydrus.desktop"
 }

--- a/media-gfx/hydrus/hydrus-9999.ebuild
+++ b/media-gfx/hydrus/hydrus-9999.ebuild
@@ -10,7 +10,7 @@ inherit git-r3 eutils python-single-r1 desktop
 DESCRIPTION="*booru style image collector and viewer"
 HOMEPAGE="http://hydrusnetwork.github.io/hydrus/ https://github.com/hydrusnetwork/hydrus"
 EGIT_REPO_URI="https://github.com/hydrusnetwork/hydrus.git"
-IUSE="+mpv +ffmpeg miniupnpc +lz4 socks matplotlib +cloudscraper charts test"
+IUSE="+mpv +ffmpeg miniupnpc +lz4 socks +cloudscraper charts test"
 
 LICENSE="WTFPL"
 SLOT="0"

--- a/media-gfx/hydrus/metadata.xml
+++ b/media-gfx/hydrus/metadata.xml
@@ -14,5 +14,6 @@
     <flag name="lz4">Enable memory compression in the client</flag>
     <flag name="socks">Support SOCKS proxies</flag>
     <flag name="cloudscraper">Support working around cloudflare anti-bot page</flag>
+    <flag name="charts">Suppot for bandwidth charts</flag>
   </use>
 </pkgmetadata>

--- a/media-gfx/hydrus/metadata.xml
+++ b/media-gfx/hydrus/metadata.xml
@@ -14,6 +14,6 @@
     <flag name="lz4">Enable memory compression in the client</flag>
     <flag name="socks">Support SOCKS proxies</flag>
     <flag name="cloudscraper">Support working around cloudflare anti-bot page</flag>
-    <flag name="charts">Suppot for bandwidth charts</flag>
+    <flag name="charts">Support for bandwidth charts</flag>
   </use>
 </pkgmetadata>


### PR DESCRIPTION
PySide2 is the recommended library to use by the developer.

python-exec is a standard practice when wrapping python scripts

Signed-off-by: Ekaterina Vaartis <vaartis@kotobank.ch>